### PR TITLE
feat: voting improvements 2 

### DIFF
--- a/src/discord/rest.ts
+++ b/src/discord/rest.ts
@@ -47,28 +47,15 @@ export const sendMessage = (
   );
 };
 
-/**
- * Edits a message on discord
- * @param channel Channel id
- * @param message Message id
- * @param content Message
- * @param embed Embed data
- */
 export const editMessage = (
   channel: string,
   message: string,
-  content: string,
-  embed: Embed[] | null = null
+  data: EditMessage
 ): Promise<Message | null> => {
-  const messageData: EditMessage = { content };
-  if (embed) {
-    messageData.embeds = embed;
-  }
-
   return rateLimiter.request<Message>(
     "PATCH",
     `/channels/${channel}/messages/${message}`,
-    messageData
+    data
   );
 };
 

--- a/src/discord/socket.ts
+++ b/src/discord/socket.ts
@@ -26,7 +26,6 @@ import {
   Status,
 } from "@/types/discord";
 
-import { editMessage, sendMessage } from "./rest";
 import WebSocket from "ws";
 
 class Socket {
@@ -160,13 +159,6 @@ class Socket {
           seq: lastS || 0,
         },
       });
-
-      // setTimeout(() => {
-      //   if (!this.resumed) {
-      //     this.logger.log("Did not resume.");
-      //     this.identify();
-      //   }
-      // }, 20000);
     } else {
       this.identify();
     }
@@ -283,45 +275,8 @@ class Socket {
     }
   }
 
-  private async handleDM(data: Message): Promise<void> {
-    if (data.author.id === "108208089987051520") {
-      const sendMessageRegex =
-        /^sudo\smessage\s(?<channel>\d*)\s(?<content>(.|\n)*)/gm;
-      const sendMatch = sendMessageRegex.exec(data.content);
-
-      if (sendMatch && sendMatch.groups?.channel && sendMatch.groups?.content) {
-        const message = await sendMessage(
-          sendMatch.groups.channel,
-          `${sendMatch.groups.content}\n[stuff](https://www.livechart.me/anime/1235)`
-        );
-        await sendMessage(
-          data.channel_id,
-          message ? "Message sent successfully" : "Failed to send message"
-        );
-        return;
-      }
-
-      const editMessageRegex =
-        /^sudo\sedit\s(?<channel>\d*)\s(?<message>\d*)\s(?<content>(.|\n)*)/gm;
-      const editMatch = editMessageRegex.exec(data.content);
-
-      if (
-        editMatch &&
-        editMatch.groups?.channel &&
-        editMatch.groups?.message &&
-        editMatch.groups?.content
-      ) {
-        const message = await editMessage(
-          editMatch.groups.channel,
-          editMatch.groups.message,
-          editMatch.groups.content
-        );
-        await sendMessage(
-          data.channel_id,
-          message ? "Message edited successfully" : "Failed to edit message"
-        );
-      }
-    }
+  private async handleDM(_data: Message): Promise<void> {
+    this.logger.log("New DM", _data);
   }
 }
 

--- a/src/modules/voting/commands/create.command.ts
+++ b/src/modules/voting/commands/create.command.ts
@@ -331,7 +331,7 @@ const componentHandler = (logger: Logger): ComponentCommandHandler => {
       data: {
         flags: InteractionCallbackDataFlags.EPHEMERAL,
         content: "",
-        embeds: [mapPollToSettingsEmbed(poll)],
+        embeds: [mapPollToSettingsEmbed(poll, data.member?.user?.id || "")],
         components,
       },
     });
@@ -360,7 +360,11 @@ const componentHandler = (logger: Logger): ComponentCommandHandler => {
       });
     }
 
-    const embed = mapPollToSettingsEmbed(poll, isNumber ? opt : undefined);
+    const embed = mapPollToSettingsEmbed(
+      poll,
+      data.member?.user?.id || "",
+      isNumber ? opt : undefined
+    );
     if (isNumber) {
       extraComponents.push({
         type: ComponentType.Button,

--- a/src/modules/voting/helpers/index.ts
+++ b/src/modules/voting/helpers/index.ts
@@ -1,0 +1,8 @@
+import { IPoll } from "#voting/models/Poll.model";
+
+export const hasExpired = (poll: IPoll): boolean => {
+  const daysInSeconds = poll.days * 60 * 60 * 24 * 1000;
+  const endingDate = +poll.startAt + daysInSeconds;
+
+  return +new Date() > endingDate;
+};

--- a/src/modules/voting/mappers/mapPollToComponents.ts
+++ b/src/modules/voting/mappers/mapPollToComponents.ts
@@ -1,12 +1,35 @@
+import { hasExpired } from "#voting/helpers";
 import { IPoll } from "#voting/models/Poll.model";
 
 import { chunkArray } from "@/helper/common";
 import { ActionRow, ButtonStyle, ComponentType } from "@/types/discord";
 
-export const mapPollToComponents = (
-  poll: IPoll,
-  prefix?: string
-): ActionRow[] => {
+export enum PollMessageType {
+  VOTE = "vote",
+  SETTINGS = "settings",
+}
+
+interface MapPollToComponents {
+  (poll: IPoll, type: PollMessageType.VOTE): ActionRow[];
+  (
+    poll: IPoll,
+    type: PollMessageType.SETTINGS,
+    user: string,
+    singleResponse?: number
+  ): ActionRow[];
+}
+
+const prefixMap = new Map([
+  [PollMessageType.VOTE, ""],
+  [PollMessageType.SETTINGS, "setOpt"],
+]);
+
+export const mapPollToComponents: MapPollToComponents = (
+  poll,
+  type: PollMessageType,
+  user?: string,
+  singleResponse?: number
+) => {
   const components: ActionRow[] = [];
 
   let i = 0;
@@ -17,10 +40,62 @@ export const mapPollToComponents = (
       components: chunk.map((option) => ({
         type: ComponentType.Button,
         style: ButtonStyle.Primary,
-        custom_id: `voting.create.${prefix ? `${prefix}.` : ""}${i++}`,
+        disabled: singleResponse === i,
+        custom_id: `voting.create.${prefixMap.get(type)}.${i++}`,
         label: option.text,
       })),
     });
+  }
+
+  if (type === PollMessageType.VOTE) {
+    components.push({
+      type: ComponentType.ActionRow,
+      components: [
+        {
+          type: ComponentType.Button,
+          style: ButtonStyle.Secondary,
+          custom_id: `voting.create.settings`,
+          label: "",
+          emoji: {
+            id: null,
+            name: "⚙",
+          },
+        },
+      ],
+    });
+  } else if (type === PollMessageType.SETTINGS) {
+    const actionRow: ActionRow = {
+      type: ComponentType.ActionRow,
+      components: [],
+    };
+
+    if (
+      !hasExpired(poll) &&
+      (user === poll.creator || poll.usersCanAddAnswers)
+    ) {
+      actionRow.components.push({
+        type: ComponentType.Button,
+        style: ButtonStyle.Secondary,
+        custom_id: `voting.create.add`,
+        emoji: {
+          id: null,
+          name: "➕",
+        },
+      });
+    }
+
+    if (singleResponse !== undefined) {
+      actionRow.components.push({
+        type: ComponentType.Button,
+        style: ButtonStyle.Secondary,
+        custom_id: `voting.create.setOpt.all`,
+        label: "Unselect options",
+      });
+    }
+
+    if (actionRow.components.length) {
+      components.push(actionRow);
+    }
   }
 
   return components;

--- a/src/modules/voting/mappers/mapPollToComponents.ts
+++ b/src/modules/voting/mappers/mapPollToComponents.ts
@@ -34,19 +34,21 @@ export const mapPollToComponents: MapPollToComponents = (
 
   let i = 0;
   const chunks = chunkArray(poll.options, 5);
-  for (const chunk of chunks) {
-    components.push({
-      type: ComponentType.ActionRow,
-      components: chunk.map((option) => ({
-        type: ComponentType.Button,
-        style: ButtonStyle.Primary,
-        disabled: singleResponse === i,
-        custom_id: `voting.create.${prefixMap.get(type)}${i++}`,
-        label: option.text,
-      })),
-    });
-  }
 
+  if (!hasExpired(poll)) {
+    for (const chunk of chunks) {
+      components.push({
+        type: ComponentType.ActionRow,
+        components: chunk.map((option) => ({
+          type: ComponentType.Button,
+          style: ButtonStyle.Primary,
+          disabled: singleResponse === i,
+          custom_id: `voting.create.${prefixMap.get(type)}${i++}`,
+          label: option.text,
+        })),
+      });
+    }
+  }
   if (type === PollMessageType.VOTE) {
     components.push({
       type: ComponentType.ActionRow,
@@ -103,6 +105,22 @@ export const mapPollToComponents: MapPollToComponents = (
       }
     }
 
+    if (isPollEditable) {
+      actionRow.components.push(
+        {
+          type: ComponentType.Button,
+          style: ButtonStyle.Danger,
+          custom_id: `voting.create.close`,
+          label: `Close the poll`,
+        },
+        {
+          type: ComponentType.Button,
+          style: ButtonStyle.Danger,
+          custom_id: `voting.create.reset`,
+          label: `Reset votes`,
+        }
+      );
+    }
     if (actionRow.components.length) {
       components.push(actionRow);
     }

--- a/src/modules/voting/mappers/mapPollToComponents.ts
+++ b/src/modules/voting/mappers/mapPollToComponents.ts
@@ -21,7 +21,7 @@ interface MapPollToComponents {
 
 const prefixMap = new Map([
   [PollMessageType.VOTE, ""],
-  [PollMessageType.SETTINGS, "setOpt"],
+  [PollMessageType.SETTINGS, "setOpt."],
 ]);
 
 export const mapPollToComponents: MapPollToComponents = (
@@ -41,7 +41,7 @@ export const mapPollToComponents: MapPollToComponents = (
         type: ComponentType.Button,
         style: ButtonStyle.Primary,
         disabled: singleResponse === i,
-        custom_id: `voting.create.${prefixMap.get(type)}.${i++}`,
+        custom_id: `voting.create.${prefixMap.get(type)}${i++}`,
         label: option.text,
       })),
     });
@@ -69,10 +69,11 @@ export const mapPollToComponents: MapPollToComponents = (
       components: [],
     };
 
-    if (
-      !hasExpired(poll) &&
-      (user === poll.creator || poll.usersCanAddAnswers)
-    ) {
+    const isPollEditable = !hasExpired(poll) && user === poll.creator;
+    const canAddAnswers =
+      !hasExpired(poll) && (user === poll.creator || poll.usersCanAddAnswers);
+
+    if (canAddAnswers) {
       actionRow.components.push({
         type: ComponentType.Button,
         style: ButtonStyle.Secondary,
@@ -91,6 +92,15 @@ export const mapPollToComponents: MapPollToComponents = (
         custom_id: `voting.create.setOpt.all`,
         label: "Unselect options",
       });
+
+      if (isPollEditable) {
+        actionRow.components.push({
+          type: ComponentType.Button,
+          style: ButtonStyle.Danger,
+          custom_id: `voting.create.remove.${singleResponse}`,
+          label: `Remove this option`,
+        });
+      }
     }
 
     if (actionRow.components.length) {

--- a/src/modules/voting/mappers/mapPollToSettingsEmbed.ts
+++ b/src/modules/voting/mappers/mapPollToSettingsEmbed.ts
@@ -4,6 +4,7 @@ import { Embed } from "@/types/discord";
 
 export const mapPollToSettingsEmbed = (
   poll: IPoll,
+  user: string,
   singleResponse?: number
 ): Embed => {
   let values: string[] = [];
@@ -33,8 +34,14 @@ export const mapPollToSettingsEmbed = (
     responses = res.responses;
   }
 
+  const userVotes = poll.options
+    .filter((o) => o.votes.includes(user))
+    .map((o) => `\`${o.text}\``)
+    .join(" ");
+
   const embed: Embed = {
     title: poll.question,
+    description: `Your votes: ${userVotes}`,
     fields: [
       {
         name: "Option",

--- a/src/modules/voting/mappers/mapPollToSettingsEmbed.ts
+++ b/src/modules/voting/mappers/mapPollToSettingsEmbed.ts
@@ -1,39 +1,28 @@
 import { IPoll } from "#voting/models/Poll.model";
 
-import { Embed } from "@/types/discord";
+import { Embed, EmbedField } from "@/types/discord";
+
+const votingEmbedFields = (
+  poll: IPoll,
+  singleResponse: number
+): EmbedField[] => {
+  const option = poll.options[singleResponse];
+
+  const responses = option.votes.map((v) => `<@${v}>`).join("\n");
+
+  return [
+    {
+      name: option.text,
+      value: responses || "No votes",
+    },
+  ];
+};
 
 export const mapPollToSettingsEmbed = (
   poll: IPoll,
   user: string,
   singleResponse?: number
 ): Embed => {
-  let values: string[] = [];
-  let responses: (number | string)[] = [];
-
-  if (singleResponse !== undefined) {
-    const option = poll.options[singleResponse];
-
-    values = [option.text];
-    responses = [option.votes.map((v) => `<@${v}>`).join("\n")];
-  } else {
-    const res = (JSON.parse(JSON.stringify(poll.options)) as IPoll["options"])
-      .sort((a, b) => b.votes.length - a.votes.length)
-      .reduce<{
-        values: string[];
-        responses: number[];
-      }>(
-        (acc, option) => {
-          acc.values.push(option.text);
-          acc.responses.push(option.votes.length);
-          return acc;
-        },
-        { values: [], responses: [] }
-      );
-
-    values = res.values;
-    responses = res.responses;
-  }
-
   const userVotes = poll.options
     .filter((o) => o.votes.includes(user))
     .map((o) => `\`${o.text}\``)
@@ -41,18 +30,12 @@ export const mapPollToSettingsEmbed = (
 
   const embed: Embed = {
     title: poll.question,
-    description: `Your votes: ${userVotes}`,
-    fields: [
-      {
-        name: "Option",
-        value: values.join("\n"),
-        inline: true,
-      },
-      {
-        name: "Responses",
-        value: responses.join("\n"),
-        inline: true,
-      },
+    description: `Your votes: ${userVotes}.\n\nClick in one of the blue buttons below to see who voted in that option.`,
+  };
+  if (singleResponse !== undefined) {
+    embed.fields = votingEmbedFields(poll, singleResponse);
+  } else {
+    embed.fields = [
       {
         name: "Creation Date",
         value: `<t:${Math.floor(+poll.startAt / 1000)}>`,
@@ -73,11 +56,13 @@ export const mapPollToSettingsEmbed = (
         value: poll.usersCanAddAnswers ? "Yes" : "No",
         inline: false,
       },
-    ],
-    footer: {
-      text: "Select an option below to see who voted on it.",
-    },
-  };
+      {
+        name: "Poll creator",
+        value: `<@${poll.creator}>`,
+        inline: false,
+      },
+    ];
+  }
 
   return embed;
 };

--- a/src/modules/voting/mappers/mapPollToSettingsEmbed.ts
+++ b/src/modules/voting/mappers/mapPollToSettingsEmbed.ts
@@ -30,7 +30,9 @@ export const mapPollToSettingsEmbed = (
 
   const embed: Embed = {
     title: poll.question,
-    description: `Your votes: ${userVotes}.\n\nClick in one of the blue buttons below to see who voted in that option.`,
+    description: `Your votes: ${
+      userVotes || "no votes"
+    }.\n\nClick in one of the blue buttons below to see who voted in that option.`,
   };
   if (singleResponse !== undefined) {
     embed.fields = votingEmbedFields(poll, singleResponse);

--- a/src/types/discord.ts
+++ b/src/types/discord.ts
@@ -390,7 +390,7 @@ export interface EditMessage {
   /** allowed mentions for the message */
   allowed_mentions?: AllowedMentions | null;
   /** the components to include with the message */
-  components?: Component[] | null;
+  components?: ActionRow[] | null;
   /** attached files to keep and possible descriptions for new files */
   attachments?: Attachment[] | null;
 }


### PR DESCRIPTION
After first tests with users, here's some problems:
- lack of editing
  - [x] we should allow the remove of answers. No edits should be allowed, only remove and add.
  - [x] possibility to reset full poll?
  - [x] close poll before the time
- people do not understand the settings message
  - [x] remove the voting from the setting pages by default
  - [x] add button to show results
  - [x] make sure people can easily understand what they voted on
  - [x] show only buttons that people can actually click on
  - [x] remove the message from the footer and make it bigger