### PR TITLE
feat(84): list upcoming anime command

### DIFF
--- a/src/modules/anilist/commands/upcoming.command.ts
+++ b/src/modules/anilist/commands/upcoming.command.ts
@@ -1,0 +1,148 @@
+import { getUpcomingAnime } from "#anilist/graphql/graphql";
+import { AnilistRateLimit } from "#anilist/helpers/rate-limiter";
+import { mapUpcomingToEmbed } from "#anilist/mappers/mapUpcomingToEmbed";
+import { MediaSeason } from "#anilist/types/graphql";
+import { CommandInfo } from "#base-module";
+
+import {
+  createInteractionResponse,
+  editOriginalInteractionResponse,
+} from "@/discord/rest";
+import {
+  CreatePageCallback,
+  InteractionPagination,
+} from "@/helper/interaction-pagination";
+import Logger from "@/helper/logger";
+import messageList from "@/helper/messages";
+import { getOptions } from "@/helper/modules";
+import { addPagination, getApplication } from "@/state/store";
+import {
+  ApplicationCommandOption,
+  ApplicationCommandOptionType,
+  CommandHandler,
+  Embed,
+  InteractionCallbackType,
+} from "@/types/discord";
+
+interface UpcomingCommandOptions {
+  season: MediaSeason | null;
+}
+
+const definition: ApplicationCommandOption = {
+  name: "upcoming",
+  description: "Shows a list of unaired animes.",
+  type: ApplicationCommandOptionType.SUB_COMMAND,
+  options: [
+    {
+      name: "season",
+      description:
+        "Season to get the upcoming animes, defaults to the next season.",
+      type: ApplicationCommandOptionType.STRING,
+      choices: [
+        {
+          name: MediaSeason.WINTER,
+          value: MediaSeason.WINTER,
+        },
+        {
+          name: MediaSeason.SPRING,
+          value: MediaSeason.SPRING,
+        },
+        {
+          name: MediaSeason.SUMMER,
+          value: MediaSeason.SUMMER,
+        },
+        {
+          name: MediaSeason.FALL,
+          value: MediaSeason.FALL,
+        },
+      ],
+    },
+  ],
+};
+
+const getNextSeason = (): MediaSeason => {
+  const date = new Date();
+
+  switch (date.getMonth()) {
+    case 0:
+    case 1:
+    case 2:
+      return MediaSeason.SPRING;
+    case 3:
+    case 4:
+    case 5:
+      return MediaSeason.SUMMER;
+    case 6:
+    case 7:
+    case 8:
+      return MediaSeason.FALL;
+    case 9:
+    case 10:
+    case 11:
+      return MediaSeason.WINTER;
+  }
+
+  return MediaSeason.WINTER;
+};
+
+const pageUpdate: CreatePageCallback<Embed> = async (_page, _total, data) => ({
+  data: {
+    embeds: [data],
+  },
+});
+
+const handler = (
+  logger: Logger,
+  rateLimiter: AnilistRateLimit
+): CommandHandler => {
+  return async (data, option) => {
+    const app = getApplication();
+    if (app && app.id && data.guild_id) {
+      await createInteractionResponse(data.id, data.token, {
+        type: InteractionCallbackType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE,
+      });
+
+      const options = getOptions<UpcomingCommandOptions>(
+        ["season"],
+        option.options
+      );
+
+      const season = options.season ?? getNextSeason();
+
+      const allData = await getUpcomingAnime(rateLimiter, season);
+
+      if (!allData) {
+        await editOriginalInteractionResponse(app.id, data.token, {
+          content: messageList.anilist.not_found,
+        });
+        return;
+      }
+
+      const embedList = mapUpcomingToEmbed(logger, allData);
+
+      if (embedList.length === 0) {
+        await editOriginalInteractionResponse(app.id, data.token, {
+          content: messageList.anilist.not_found,
+        });
+        return;
+      }
+
+      const pagination = new InteractionPagination(
+        app.id,
+        embedList,
+        pageUpdate
+      );
+
+      await pagination.create(data.token);
+      addPagination(pagination as InteractionPagination);
+    }
+  };
+};
+
+export default (
+  logger: Logger,
+  rateLimiter: AnilistRateLimit
+): CommandInfo => ({
+  definition,
+  handler: handler(logger, rateLimiter),
+});

--- a/src/modules/anilist/graphql/graphql.ts
+++ b/src/modules/anilist/graphql/graphql.ts
@@ -4,13 +4,16 @@ import {
   MediaForAiring,
   MediaList,
   MediaResponse,
+  MediaSeason,
   MediaSubbed,
   MediaType,
   NextAiringWithTitle,
   PageResponse,
+  UpcomingMedia,
 } from "../types/graphql";
 import { getAiringScheduleGraphql } from "./queries/getAiringScheduleGraphql";
 import { getFullAiringScheduleGraphql } from "./queries/getFullAiringScheduleGraphql";
+import { getUpcoming } from "./queries/getUpcoming";
 import { searchByIdsGraphql } from "./queries/searchByIdsGraphql";
 import { searchByTypeGraphql } from "./queries/searchByTypeGraphql";
 import { searchForAiringScheduleGraphql } from "./queries/searchForAiringScheduleGraphql";
@@ -91,6 +94,19 @@ export const getFullAiringSchedule = async (
     getFullAiringScheduleGraphql,
     {
       id,
+    }
+  );
+};
+
+export const getUpcomingAnime = async (
+  rateLimiter: IAnilistRateLimit,
+  season: MediaSeason
+): Promise<PageResponse<UpcomingMedia> | null> => {
+  return await rateLimiter.request<PageResponse<UpcomingMedia>>(
+    "getUpcoming",
+    getUpcoming,
+    {
+      season,
     }
   );
 };

--- a/src/modules/anilist/graphql/queries/getUpcoming.ts
+++ b/src/modules/anilist/graphql/queries/getUpcoming.ts
@@ -1,0 +1,59 @@
+export const getUpcoming = `
+query ($season: MediaSeason) {
+  Page(perPage: 50) {
+    media(type: ANIME, status: NOT_YET_RELEASED, season: $season, sort: POPULARITY_DESC) {
+      id
+      idMal
+      title {
+        romaji
+        english
+        native
+      }
+      format
+      description(asHtml: false)
+      startDate {
+        year
+        month
+        day
+      }
+      episodes
+      duration
+      countryOfOrigin
+      source
+      trailer {
+        id
+        site
+        thumbnail
+      }
+      updatedAt
+      coverImage {
+        extraLarge
+        large
+        medium
+        color
+      }
+      genres
+      tags {
+        name
+        isMediaSpoiler
+      }
+      studios {
+        nodes {
+          name
+        }
+      }
+      isAdult
+      nextAiringEpisode {
+        airingAt
+        timeUntilAiring
+        episode
+      }
+      externalLinks {
+        url
+        site
+      }
+      siteUrl
+    }
+  }
+}
+`;

--- a/src/modules/anilist/mappers/helperMappers.ts
+++ b/src/modules/anilist/mappers/helperMappers.ts
@@ -1,0 +1,40 @@
+import { Date, Trailer } from "../types/graphql";
+
+export const cleanUpDescription = (description: string): string => {
+  return description
+    .replace(/<br>/g, "")
+    .replace(/<i>/g, "*")
+    .replace(/<\/i>/g, "*");
+};
+
+export const dateToString = (date: Date): string => {
+  if (!date.year) {
+    return ``;
+  }
+  if (!date.month) {
+    return `${date.year}`;
+  }
+  if (!date.day) {
+    return `${date.year}-${date.month}`;
+  }
+  return `${date.year}-${date.month}-${date.day}`;
+};
+
+export const formatReleasingDate = (start: Date, end: Date): string | null => {
+  if (!start.year) {
+    return null;
+  }
+
+  if (!end.year) {
+    return dateToString(start);
+  }
+
+  return `${dateToString(start)} - ${dateToString(end)}`;
+};
+
+export const formatTrailerLink = (trailer: Trailer): string => {
+  if (trailer.site === "youtube") {
+    return `https://youtu.be/${trailer.id}`;
+  }
+  return `${trailer.site} - ${trailer.id}`;
+};

--- a/src/modules/anilist/module.ts
+++ b/src/modules/anilist/module.ts
@@ -6,6 +6,7 @@ import channelCommand from "./commands/channel.command";
 import scheduleCommand from "./commands/schedule.command";
 import searchCommand from "./commands/search.command";
 import subCommand from "./commands/sub.command";
+import upcomingCommand from "./commands/upcoming.command";
 import { getAllAnimeLastAiring } from "./database";
 import { AnimeManager } from "./helpers/anime-manager";
 import { AnilistRateLimit } from "./helpers/rate-limiter";
@@ -35,6 +36,7 @@ export default class AnilistModule extends BaseModule {
       ),
       schedule: scheduleCommand(this.logger, this.rateLimiter),
       channel: channelCommand(this.logger),
+      upcoming: upcomingCommand(this.logger, this.rateLimiter),
     };
   }
 

--- a/src/modules/anilist/types/graphql.ts
+++ b/src/modules/anilist/types/graphql.ts
@@ -121,6 +121,12 @@ interface MediaTitle {
   userPreferred: string;
 }
 
+export interface Trailer {
+  id: string;
+  site: string;
+  thumbnail: string;
+}
+
 interface Media {
   id: number;
   idMal: number | null;
@@ -136,7 +142,9 @@ interface Media {
   duration: number | null;
   volumes: number | null;
   isLicensed: boolean;
+  countryOfOrigin: string;
   source: MediaSource | null;
+  trailer: Trailer | null;
   updatedAt: number;
   coverImage: MediaCoverImage;
   genres: string[] | null;
@@ -151,8 +159,8 @@ interface Media {
   siteUrl: string;
 }
 
-export interface MediaList {
-  media: Media[];
+export interface MediaList<T = Media> {
+  media: T[];
 }
 
 interface PageInfo {
@@ -228,3 +236,30 @@ export interface AiringScheduleResponse {
 export interface Response<T> {
   data: T;
 }
+
+export type UpcomingMedia = MediaList<
+  Pick<
+    Media,
+    | "id"
+    | "idMal"
+    | "title"
+    | "format"
+    | "description"
+    | "startDate"
+    | "episodes"
+    | "duration"
+    | "countryOfOrigin"
+    | "source"
+    | "trailer"
+    | "updatedAt"
+    | "coverImage"
+    | "genres"
+    | "studios"
+    | "isAdult"
+    | "nextAiringEpisode"
+    | "externalLinks"
+    | "siteUrl"
+  > & {
+    tags: { name: string; isMediaSpoiler: boolean }[];
+  }
+>;


### PR DESCRIPTION
## What this PR do / why do we need it:

Creates a new command in the anilist module to get the upcoming animes. By default it searches for the next season, if the user does not select a specific season.

###  Added

- Command to get the upcoming animes in anilist module

### Changed

- Updated the way the page selector for the pagination is created to prevent errors for more than 50 entries

## Which issue(s) do(does) this PR solve(s):
Closes: #84 

## Special notes for your reviewer:

