### PR TITLE
fix: potential fix for code scanning alert no 1 Resource exhaustion

### DIFF
--- a/src/discord/socket.ts
+++ b/src/discord/socket.ts
@@ -147,10 +147,28 @@ export class Socket {
       clearInterval(this.hbInterval);
     }
 
+    // Validate the heartbeat_interval to prevent resource exhaustion
+    const MIN_HEARTBEAT_INTERVAL = 1000;      // 1 second
+    const MAX_HEARTBEAT_INTERVAL = 120000;    // 2 minutes
+    const interval = typeof data.heartbeat_interval === "number" ? data.heartbeat_interval : NaN;
+    if (
+      !Number.isFinite(interval) ||
+      interval < MIN_HEARTBEAT_INTERVAL ||
+      interval > MAX_HEARTBEAT_INTERVAL
+    ) {
+      this.logger.error(
+        "Invalid heartbeat_interval received from server",
+        { received: data.heartbeat_interval }
+      );
+      // Close the connection and retry
+      this.client?.close();
+      return;
+    }
+
     this.hbInterval = setInterval(() => {
       this.sendHeartbeat();
-      this.logger.info("hb", { heartbeat_interval: data.heartbeat_interval });
-    }, data.heartbeat_interval);
+      this.logger.info("hb", { heartbeat_interval: interval });
+    }, interval);
 
     const sessionId = getDiscordSession();
     const lastS = getDiscordLastS();

--- a/src/discord/socket.ts
+++ b/src/discord/socket.ts
@@ -29,10 +29,16 @@ import Logger from "@/helper/logger";
 
 import WebSocket from "ws";
 
+const MIN_HEARTBEAT_INTERVAL = 1000;
+const MAX_HEARTBEAT_INTERVAL = 120000;
+
 export class Socket {
   private logger = new Logger("socket");
 
   private hbInterval: NodeJS.Timeout | null = null;
+
+  // Timeout used for the initial jittered heartbeat
+  private hbTimeout: NodeJS.Timeout | null = null;
 
   private hbAck = true;
 
@@ -66,7 +72,14 @@ export class Socket {
 
   public disconnect() {
     this.client?.close(1001);
-    this.hbInterval && clearTimeout(this.hbInterval);
+    if (this.hbInterval) {
+      clearInterval(this.hbInterval);
+      this.hbInterval = null;
+    }
+    if (this.hbTimeout) {
+      clearTimeout(this.hbTimeout);
+      this.hbTimeout = null;
+    }
   }
 
   // EVENTS
@@ -79,6 +92,11 @@ export class Socket {
 
     if (this.hbInterval) {
       clearInterval(this.hbInterval);
+      this.hbInterval = null;
+    }
+    if (this.hbTimeout) {
+      clearTimeout(this.hbTimeout);
+      this.hbTimeout = null;
     }
 
     if (e === 4005) {
@@ -143,32 +161,48 @@ export class Socket {
   private onHello(data: GatewayHelloData): void {
     this.logger.info("Received Hello");
 
+    // Clear any existing heartbeat timers
     if (this.hbInterval) {
       clearInterval(this.hbInterval);
+      this.hbInterval = null;
+    }
+    if (this.hbTimeout) {
+      clearTimeout(this.hbTimeout);
+      this.hbTimeout = null;
     }
 
-    // Validate the heartbeat_interval to prevent resource exhaustion
-    const MIN_HEARTBEAT_INTERVAL = 1000;      // 1 second
-    const MAX_HEARTBEAT_INTERVAL = 120000;    // 2 minutes
     const interval = typeof data.heartbeat_interval === "number" ? data.heartbeat_interval : NaN;
     if (
-      !Number.isFinite(interval) ||
-      interval < MIN_HEARTBEAT_INTERVAL ||
-      interval > MAX_HEARTBEAT_INTERVAL
+      !Number.isFinite(interval)
+      || interval < MIN_HEARTBEAT_INTERVAL
+      || interval > MAX_HEARTBEAT_INTERVAL
     ) {
       this.logger.error(
         "Invalid heartbeat_interval received from server",
-        { received: data.heartbeat_interval }
+        { received: data.heartbeat_interval },
       );
       // Close the connection and retry
       this.client?.close();
       return;
     }
 
-    this.hbInterval = setInterval(() => {
+    // Per Discord docs: send the first heartbeat after heartbeat_interval * jitter
+    // where jitter is a random value between 0 and 1. Subsequent heartbeats
+    // should be sent every `interval` milliseconds.
+    const jitter = Math.random();
+    const initialDelay = Math.floor(interval * jitter);
+
+    this.hbTimeout = setTimeout(() => {
       this.sendHeartbeat();
-      this.logger.info("hb", { heartbeat_interval: interval });
-    }, interval);
+      this.logger.info("hb (initial)", { heartbeat_interval: interval, jitter, initialDelay });
+
+      // Start the regular interval after the initial jittered heartbeat
+      this.hbInterval = setInterval(() => {
+        this.sendHeartbeat();
+        this.logger.info("hb", { heartbeat_interval: interval });
+      }, interval);
+      this.hbTimeout = null;
+    }, initialDelay);
 
     const sessionId = getDiscordSession();
     const lastS = getDiscordLastS();


### PR DESCRIPTION
Potential fix for [https://github.com/Kimossab/kimoo-disc-bot/security/code-scanning/1](https://github.com/Kimossab/kimoo-disc-bot/security/code-scanning/1)

The `heartbeat_interval` value from the Gateway Hello event must be validated before being used as the interval for `setInterval`. The best approach is to check that the interval is both a number and falls within a safe, reasonable range (e.g., between 1000ms (1s) and 120,000ms (2 minutes)), or whatever is considered valid as per Discord documentation or acceptable application requirements. If the value is not within the acceptable range, the socket should close or reconnect, logging an error to avoid a resource exhaustion situation. The code should implement this validation in `onHello`, before `setInterval`, and return or handle the error if the validation fails.

Changes needed:
- In `onHello`, add validation for `data.heartbeat_interval` for number type and bounds.
- Handle invalid intervals (log error and close/reconnect the socket).
- No new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
