### PR TITLE
ci: potential fix for code scanning alert no 2 to 4 Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,4 +1,6 @@
 ﻿name: PRValidation
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,6 @@
 name: Build on pull request
+permissions:
+  contents: read
 
 on: pull_request
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/Kimossab/kimoo-disc-bot/security/code-scanning/2](https://github.com/Kimossab/kimoo-disc-bot/security/code-scanning/2)

The safest and preferred way to fix this issue is to add a `permissions` block at the root of the workflow file, immediately after the `name` and before the `on`. This will establish the least privilege principle by setting the GITHUB_TOKEN permissions for all jobs in the workflow to a minimal necessary value. For this workflow, read access to the repository contents is sufficient, so `permissions: contents: read` should be used. No other modifications to steps, jobs, or external dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
